### PR TITLE
TEST: Stress test exponent regex

### DIFF
--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -349,9 +349,7 @@ ws = re.compile(r'[ \t]*')                       # Whitespace not including NL
 signed_integer = re.compile(r'[-+]?[0-9]+')      # integer
 integer_syntax = re.compile(r'[-+]?[0-9]+')
 decimal_syntax = re.compile(r'[-+]?[0-9]*\.[0-9]+')
-exponent_syntax = re.compile(r'[-+]?(?:[0-9]+\.[0-9]*(?:e|E)[-+]?[0-9]+|'+
-                             r'\.[0-9]+(?:e|E)[-+]?[0-9]+|'+
-                             r'[0-9]+(?:e|E)[-+]?[0-9]+)')
+exponent_syntax = re.compile(r'[-+]?(?:[0-9]+\.[0-9]*|\.[0-9]+|[0-9]+)(?:e|E)[-+]?[0-9]+')
 digitstring = re.compile(r'[0-9]+')              # Unsigned integer
 interesting = re.compile(r"""[\\\r\n\"\']""")
 langcode = re.compile(r'[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*')

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,12 @@ from setuptools import setup, find_packages
 
 kwargs = {}
 kwargs['install_requires'] = [ 'six', 'isodate', 'pyparsing']
-kwargs['tests_require'] = ['html5lib', 'networkx']
+kwargs['tests_require'] = ['html5lib', 'networkx', 'nose', 'doctest-ignore-unicode']
 kwargs['test_suite'] = "nose.collector"
 kwargs['extras_require'] = {
     'html': ['html5lib'],
     'sparql': ['requests'],
+    'tests': kwargs['tests_require'],
     'docs': ['sphinx < 3', 'sphinxcontrib-apidoc']
     }
 

--- a/test/test_n3.py
+++ b/test/test_n3.py
@@ -1,7 +1,8 @@
 from rdflib.graph import Graph, ConjunctiveGraph
 import unittest
 from rdflib.term import Literal, URIRef
-from rdflib.plugins.parsers.notation3 import BadSyntax
+from rdflib.plugins.parsers.notation3 import BadSyntax, exponent_syntax
+import itertools
 
 from six import b
 from six.moves.urllib.error import URLError
@@ -249,6 +250,25 @@ foo-bar:Ex foo-bar:name "Test" . """
 
         assert set(g1) == set(
             g2), 'Document with declared empty prefix must match default #'
+
+
+class TestRegularExpressions(unittest.TestCase):
+    def testExponents(self):
+        signs = ("", "+", "-")
+        mantissas = ("1", "1.", ".1",
+                     "12", "12.", "1.2", ".12",
+                     "123", "123.", "12.3", "1.23", ".123")
+        es = "eE"
+        exps = ("1", "12", "+1", "-1", "+12", "-12")
+        for parts in itertools.product(signs, mantissas, es, exps):
+            expstring = "".join(parts)
+            self.assertRegex(expstring, exponent_syntax)
+
+    def testInvalidExponents(self):
+        # Add test cases as needed
+        invalid = (".e1",)
+        for expstring in invalid:
+            self.assertNotRegex(expstring, exponent_syntax)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add-on to rdflib#1012. Wanted to just stress test the exponent regex to make sure it's sensible, and realized we can simplify the regex by factoring out the exponent part from the `(mantissa1|mantissa2|mantissa3)` section. Updated the test metadata in `setup.py` because nose was basically missing.